### PR TITLE
Replaced basename() by dirname() to build file paths.

### DIFF
--- a/lib/ipn/PPIPNMessage.php
+++ b/lib/ipn/PPIPNMessage.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once basename(__FILE__) . '/../PPConfigManager.php';
-require_once basename(__FILE__) . '/../PPConnectionManager.php';
-require_once basename(__FILE__) . '/../PPHttpConfig.php';
+require_once dirname(__FILE__) . '/../PPConfigManager.php';
+require_once dirname(__FILE__) . '/../PPConnectionManager.php';
+require_once dirname(__FILE__) . '/../PPHttpConfig.php';
 
 /**
  * 


### PR DESCRIPTION
Error occured by require_once because file paths were wrong. I fixed it by using dirname() instead of basename(). Please talke a look.
