### PR TITLE
Add RiskSessionCorrelationID

### DIFF
--- a/lib/PayPal/EBLBaseComponents/DoReferenceTransactionRequestDetailsType.php
+++ b/lib/PayPal/EBLBaseComponents/DoReferenceTransactionRequestDetailsType.php
@@ -59,6 +59,15 @@ class DoReferenceTransactionRequestDetailsType
     public $IPAddress;
 
     /**
+     * Correlation id related to risk process done for the device.
+     * Max length is 36 Chars.
+     * @access    public
+     * @namespace ebl
+     * @var string
+     */
+    public $RiskSessionCorrelationID;
+
+    /**
      *
      * @access    public
      * @namespace ebl


### PR DESCRIPTION
Adds `RiskSessionCorrelationID` field to `DoReferenceTransactionRequestDetailsType`.