### PR TITLE
Changed name of class because deprecation with composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "paypal/sdk-core-php":"3.*"
+        "protonlabs/paypal-sdk-core-php":"3.*"
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,11 @@
             "PayPal\\EnhancedDataTypes": "lib/",
             "PayPal\\PayPalAPI": "lib/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "url": "https://github.com/filmin/sdk-core-php",
+            "type": "vcs"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "filmin/paypal-sdk-core-php":"3.*"
+        "filmin/paypal-sdk-core-php":"dev-master"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paypal/merchant-sdk-php",
+    "name": "filmin/merchant-sdk-php",
     "description": "PayPal Merchant SDK for PHP",
     "keywords": ["paypal", "php", "sdk"],
     "homepage": "https://developer.paypal.com",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "protonlabs/paypal-sdk-core-php":"3.*"
+        "filmin/paypal-sdk-core-php":"3.*"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/lib/PayPal/EBLBaseComponents/BillingPeriodDetailsTypeUpdate.php
+++ b/lib/PayPal/EBLBaseComponents/BillingPeriodDetailsTypeUpdate.php
@@ -6,7 +6,7 @@ use PayPal\Core\PPXmlMessage;
 /**
  * Unit of meausre for billing cycle
  */
-class BillingPeriodDetailsType_Update
+class BillingPeriodDetailsTypeUpdate
   extends PPXmlMessage
 {
 

--- a/lib/PayPal/EBLBaseComponents/UpdateRecurringPaymentsProfileRequestDetailsType.php
+++ b/lib/PayPal/EBLBaseComponents/UpdateRecurringPaymentsProfileRequestDetailsType.php
@@ -135,7 +135,7 @@ class UpdateRecurringPaymentsProfileRequestDetailsType
      * Trial period of this schedule
      * @access    public
      * @namespace ebl
-     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsType_Update
+     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsTypeUpdate
      */
     public $TrialPeriod;
 
@@ -143,7 +143,7 @@ class UpdateRecurringPaymentsProfileRequestDetailsType
      *
      * @access    public
      * @namespace ebl
-     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsType_Update
+     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsTypeUpdate
      */
     public $PaymentPeriod;
 


### PR DESCRIPTION
Composer v2 is coming soon, so when you try to install this library, you receive a Deprecation notice:

`Deprecation Notice: Class PayPal\EBLBaseComponents\BillingPeriodDetailsType_Update located in ./vendor/paypal/merchant-sdk-php/lib/PayPal/EBLBaseComponents/BillingPeriodDetailsType_Update.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201`

In order to have PSR-0 standard (https://www.php-fig.org/psr/psr-0/#mandatory) we should create a directory: BillingPeriodDetailsType/Update.php but I think that in this is case is better: BillingPeriodDetailsTypeUpdate.php

Fixes: #161 