### PR TITLE
Composer v2 compatibility

### DIFF
--- a/lib/PayPal/EBLBaseComponents/BillingPeriodDetailsTypeUpdate.php
+++ b/lib/PayPal/EBLBaseComponents/BillingPeriodDetailsTypeUpdate.php
@@ -6,7 +6,7 @@ use PayPal\Core\PPXmlMessage;
 /**
  * Unit of meausre for billing cycle
  */
-class BillingPeriodDetailsType_Update
+class BillingPeriodDetailsTypeUpdate
   extends PPXmlMessage
 {
 

--- a/lib/PayPal/EBLBaseComponents/UpdateRecurringPaymentsProfileRequestDetailsType.php
+++ b/lib/PayPal/EBLBaseComponents/UpdateRecurringPaymentsProfileRequestDetailsType.php
@@ -135,7 +135,7 @@ class UpdateRecurringPaymentsProfileRequestDetailsType
      * Trial period of this schedule
      * @access    public
      * @namespace ebl
-     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsType_Update
+     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsTypeUpdate
      */
     public $TrialPeriod;
 
@@ -143,7 +143,7 @@ class UpdateRecurringPaymentsProfileRequestDetailsType
      *
      * @access    public
      * @namespace ebl
-     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsType_Update
+     * @var \PayPal\EBLBaseComponents\BillingPeriodDetailsTypeUpdate
      */
     public $PaymentPeriod;
 


### PR DESCRIPTION
Make this project compatible with composer v2, fix https://github.com/paypal/merchant-sdk-php/issues/161

> `Deprecation Notice: Class PayPal\EBLBaseComponents\BillingPeriodDetailsTypeUpdate located in ./lib/PayPal/EBLBaseComponents/BillingPeriodDetailsType_Update.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201`